### PR TITLE
Release to Maven Central from TravisCI

### DIFF
--- a/samples/webserver/pom.xml
+++ b/samples/webserver/pom.xml
@@ -7,6 +7,7 @@
     <artifactId>webserver-sample</artifactId>
     <version>0.3.2-SNAPSHOT</version>
     <packaging>jar</packaging>
+    <name>Operator SDK - Samples - Web Server</name>
 
     <properties>
         <java.version>11</java.version>


### PR DESCRIPTION
Every build is now pushed to Maven Central. It is up to the developer to increment versions. When the repo has a SNAPSHOT version it will be pushed to Central with that version if it's a non-snapshot it will go the main release repo.

This doesn't solve Github releases or releasing the Docker image from webserver sample.