### PR TITLE
Exiting the application when there was Kubernetes exception in fabric…

### DIFF
--- a/operator-framework/src/main/java/com/github/containersolutions/operator/EventDispatcher.java
+++ b/operator-framework/src/main/java/com/github/containersolutions/operator/EventDispatcher.java
@@ -111,6 +111,9 @@ public class EventDispatcher<R extends CustomResource> implements Watcher<R> {
     public void onClose(KubernetesClientException e) {
         if (e != null) {
             log.error("Error: ", e);
+            // we will exit the application if there was a watching exception, because of the bug in fabric8 client
+            // see https://github.com/fabric8io/kubernetes-client/issues/1318
+            System.exit(1);
         }
     }
 }


### PR DESCRIPTION
This fixes the error that can occur during watching resources on the cluster.
See the link below for more info:
https://github.com/fabric8io/kubernetes-client/issues/1318 