### PR TITLE
Return a parameterized version of the CustomResourceOperationsImpl object

### DIFF
--- a/operator-framework/src/main/java/com/github/containersolutions/operator/Operator.java
+++ b/operator-framework/src/main/java/com/github/containersolutions/operator/Operator.java
@@ -7,6 +7,7 @@ import com.github.containersolutions.operator.processing.retry.GenericRetry;
 import com.github.containersolutions.operator.processing.retry.Retry;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
@@ -99,7 +100,8 @@ public class Operator {
         return customResourceClients;
     }
 
-    public <T extends CustomResource> CustomResourceOperationsImpl getCustomResourceClients(Class<T> customResourceClass) {
+    public <T extends CustomResource, L extends CustomResourceList<T>, D extends CustomResourceDoneable<T>> CustomResourceOperationsImpl<T, L, D> 
+    getCustomResourceClients(Class<T> customResourceClass) {
         return customResourceClients.get(customResourceClass);
     }
 


### PR DESCRIPTION
Currently, the `getCustomResourceClients(Class<T> crc)` method returns a raw version of the CustomResourceOperationsImpl object, so it is not possible to call the `getItems()` method when you want a list of all your custom resources:
```java
List<MyCR> crs = operator.getCustomResourceClients(MyCR.class)
    .inNamespace("default")
    .list()
    .getItems();
```
This pull request modifies the `getCustomResourceClients(Class<T> crc)` method to return a parameterized version of the CustomResourceOperationsImpl object to make this possible.