### PR TITLE
fix for generation aware retries issue

### DIFF
--- a/operator-framework/src/main/java/com/github/containersolutions/operator/processing/EventStore.java
+++ b/operator-framework/src/main/java/com/github/containersolutions/operator/processing/EventStore.java
@@ -8,6 +8,7 @@ public class EventStore {
     private final Map<String, CustomResourceEvent> eventsNotScheduled = new HashMap<>();
     private final Map<String, CustomResourceEvent> eventsUnderProcessing = new HashMap<>();
     private final Map<String, Long> lastGeneration = new HashMap<>();
+    private final Map<String, CustomResourceEvent> receivedLastEventForGenerationAwareRetry = new HashMap<>();
 
     public boolean containsNotScheduledEvent(String uuid) {
         return eventsNotScheduled.containsKey(uuid);
@@ -52,7 +53,16 @@ public class EventStore {
         return lastGeneration.get(event.getResource().getMetadata().getUid());
     }
 
-    public void removeLastGenerationForDeletedResource(String uuid) {
+    public void addLastEventForGenerationAwareRetry(CustomResourceEvent event) {
+        receivedLastEventForGenerationAwareRetry.put(event.resourceUid(), event);
+    }
+
+    public CustomResourceEvent getReceivedLastEventForGenerationAwareRetry(String uuid) {
+        return receivedLastEventForGenerationAwareRetry.get(uuid);
+    }
+
+    public void cleanup(String uuid) {
         lastGeneration.remove(uuid);
+        receivedLastEventForGenerationAwareRetry.remove(uuid);
     }
 }


### PR DESCRIPTION
This is a fix for an issue with the new generation aware scheduling for retries, when we received an update which did not increased the generation while a controller was in execution and tried to do an update.