### PR TITLE
Store mysql credentials in k8s secret

### DIFF
--- a/samples/mysql-schema/k8s/crd.yaml
+++ b/samples/mysql-schema/k8s/crd.yaml
@@ -16,6 +16,8 @@ spec:
       properties:
         spec:
           type: object
+          required:
+          - encoding
           properties:
             encoding:
               type: string

--- a/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/MySQLSchemaOperator.java
+++ b/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/MySQLSchemaOperator.java
@@ -4,6 +4,7 @@ import com.github.containersolutions.operator.Operator;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.takes.facets.fork.FkRegex;
@@ -21,8 +22,9 @@ public class MySQLSchemaOperator {
         log.info("MySQL Schema Operator starting");
 
         Config config = new ConfigBuilder().withNamespace(null).build();
-        Operator operator = new Operator(new DefaultKubernetesClient(config));
-        operator.registerControllerForAllNamespaces(new SchemaController());
+        KubernetesClient client = new DefaultKubernetesClient(config);
+        Operator operator = new Operator(client);
+        operator.registerControllerForAllNamespaces(new SchemaController(client));
 
         new FtBasic(
                 new TkFork(new FkRegex("/health", "ALL GOOD!")), 8080

--- a/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/SchemaController.java
+++ b/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/SchemaController.java
@@ -2,6 +2,10 @@ package com.github.containersolutions.operator.sample;
 
 import com.github.containersolutions.operator.api.Controller;
 import com.github.containersolutions.operator.api.ResourceController;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.commons.lang.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,6 +13,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Base64;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -17,9 +22,14 @@ import static java.lang.String.format;
         crdName = "schemas.mysql.sample.javaoperatorsdk",
         customResourceClass = Schema.class)
 public class SchemaController implements ResourceController<Schema> {
-
+    static final String USERNAME_FORMAT = "%s-user";
+    static final String SECRET_FORMAT = "%s-secret";
 
     private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final KubernetesClient kubernetesClient;
+
+    public SchemaController(KubernetesClient kubernetesClient) { this.kubernetesClient = kubernetesClient; }
 
     @Override
     public Optional<Schema> createOrUpdateResource(Schema schema) {
@@ -29,14 +39,36 @@ public class SchemaController implements ResourceController<Schema> {
                         schema.getMetadata().getName(),
                         schema.getSpec().getEncoding()));
 
+                String password = RandomStringUtils.randomAlphanumeric(16);
+                String userName = String.format(USERNAME_FORMAT,
+                        schema.getMetadata().getName());
+                String secretName = String.format(SECRET_FORMAT,
+                        schema.getMetadata().getName());
+                connection.createStatement().execute(format(
+                        "CREATE USER '%1$s' IDENTIFIED BY '%2$s'",
+                        userName, password));
+                connection.createStatement().execute(format(
+                        "GRANT ALL ON `%1$s`.* TO '%2$s'",
+                        schema.getMetadata().getName(), userName));
+                Secret credentialsSecret = new SecretBuilder()
+                        .withNewMetadata().withName(secretName).endMetadata()
+                        .addToData("MYSQL_USERNAME", Base64.getEncoder().encodeToString(userName.getBytes()))
+                        .addToData("MYSQL_PASSWORD", Base64.getEncoder().encodeToString(password.getBytes()))
+                        .build();
+                this.kubernetesClient.secrets()
+                        .inNamespace(schema.getMetadata().getNamespace())
+                        .create(credentialsSecret);
+
                 SchemaStatus status = new SchemaStatus();
                 status.setUrl(format("jdbc:mysql://%1$s/%2$s",
                         System.getenv("MYSQL_HOST"),
                         schema.getMetadata().getName()));
+                status.setUserName(userName);
+                status.setSecretName(secretName);
                 status.setStatus("CREATED");
                 schema.setStatus(status);
-
                 log.info("Schema {} created", schema.getMetadata().getName());
+
                 return Optional.of(schema);
             }
             return Optional.empty();
@@ -45,6 +77,8 @@ public class SchemaController implements ResourceController<Schema> {
 
             SchemaStatus status = new SchemaStatus();
             status.setUrl(null);
+            status.setUserName(null);
+            status.setSecretName(null);
             status.setStatus("ERROR");
             schema.setStatus(status);
 
@@ -60,6 +94,16 @@ public class SchemaController implements ResourceController<Schema> {
             if (schemaExists(connection, schema.getMetadata().getName())) {
                 connection.createStatement().execute("DROP DATABASE `" + schema.getMetadata().getName() + "`");
                 log.info("Deleted Schema '{}'", schema.getMetadata().getName());
+
+                if (userExists(connection, schema.getStatus().getUserName())) {
+                    connection.createStatement().execute("DROP USER '" + schema.getStatus().getUserName() + "'");
+                    log.info("Deleted User '{}'", schema.getStatus().getUserName());
+                }
+
+                this.kubernetesClient.secrets()
+                        .inNamespace(schema.getMetadata().getNamespace())
+                        .withName(schema.getStatus().getSecretName())
+                        .delete();
             } else {
                 log.info("Delete event ignored for schema '{}', real schema doesn't exist",
                         schema.getMetadata().getName());
@@ -86,4 +130,10 @@ public class SchemaController implements ResourceController<Schema> {
         return resultSet.first();
     }
 
+    private boolean userExists(Connection connection, String userName) throws  SQLException {
+        ResultSet resultSet = connection.createStatement().executeQuery(
+                format("SELECT User FROM mysql.user WHERE User='%1$s'", userName)
+        );
+        return resultSet.first();
+    }
 }

--- a/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/SchemaSpec.java
+++ b/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/SchemaSpec.java
@@ -11,4 +11,5 @@ public class SchemaSpec {
     public void setEncoding(String encoding) {
         this.encoding = encoding;
     }
+
 }

--- a/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/SchemaStatus.java
+++ b/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/SchemaStatus.java
@@ -6,6 +6,10 @@ public class SchemaStatus {
 
     private String status;
 
+    private String userName;
+
+    private String secretName;
+
     public String getUrl() {
         return url;
     }
@@ -21,4 +25,12 @@ public class SchemaStatus {
     public void setStatus(String status) {
         this.status = status;
     }
+
+    public String getUserName() { return userName; }
+
+    public void setUserName(String userName) { this.userName = userName; }
+
+    public String getSecretName() { return secretName; }
+
+    public void setSecretName(String secretName) { this.secretName = secretName; }
 }


### PR DESCRIPTION
This patch addresses https://github.com/ContainerSolutions/java-operator-sdk/issues/113 by creating a predictable MySQL user with granted privileges over the created schema. The credentials are stored as a K8s secret in the namespace where the schema is created.