### PR TITLE
SchemaController: User PreparedStatements where possible

### DIFF
--- a/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/SchemaController.java
+++ b/samples/mysql-schema/src/main/java/com/github/containersolutions/operator/sample/SchemaController.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -140,17 +141,22 @@ public class SchemaController implements ResourceController<Schema> {
     }
 
     private boolean schemaExists(Connection connection, String schemaName) throws SQLException {
-        ResultSet resultSet = connection.createStatement().executeQuery(
-                format("SELECT schema_name FROM information_schema.schemata WHERE schema_name = \"%1$s\"",
-                        schemaName));
-        return resultSet.first();
+        try (PreparedStatement ps =
+                     connection.prepareStatement("SELECT schema_name FROM information_schema.schemata WHERE schema_name = ?")) {
+            ps.setString(1, schemaName);
+            try (ResultSet resultSet = ps.executeQuery()) {
+                return resultSet.first();
+            }
+        }
     }
 
     private boolean userExists(Connection connection, String userName) throws SQLException {
-        try (Statement statement = connection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery(format("SELECT User FROM mysql.user WHERE User='%1$s'",
-                userName));
-            return resultSet.first();
+        try (PreparedStatement ps =
+                     connection.prepareStatement("SELECT User FROM mysql.user WHERE User = ?")) {
+            ps.setString(1, userName);
+            try (ResultSet resultSet = ps.executeQuery()) {
+                return resultSet.first();
+            }
         }
     }
 }


### PR DESCRIPTION
Use `PreparedStatement`s where possible in the `SchemaController` in order to avoid SQL Injections.

Note that `PreparedSatement`s can only dynamically bind values and not object names, so this technique could only be applied to the queries, and not the DDL statements. The security around these statements can probably be improved by sanitizing the schema values, but it's out of the scope of this PR.

As a side bonus, this PR also uses the try-with-resource idiom when creating these `PreparedStatement`s and `ResultSet`s so they will be properly closed instead of the current implementation that may leak resources.

Closes #120